### PR TITLE
rake install:upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ bundle exec rails webpacker:install
 bundle exec rake webpacker:install
 ```
 
+### Upgrading
+
+When upgrading the webpacker gem you will need to run the `install:upgrade` task.  
+
+```bash
+bundle exec rails webpacker:install:upgrade
+
+# OR (on rails version < 5.0)
+bundle exec rake webpacker:install:upgrade
+```
+
+Please check in any resulting changes in the ruby binstubs, package.json or yarn.lock.
+
 ### Usage
 
 Once installed you can start writing modern ES6-flavored JavaScript app today:

--- a/lib/install/upgrade.rb
+++ b/lib/install/upgrade.rb
@@ -1,0 +1,10 @@
+require "webpacker/configuration"
+
+puts "Upgrading binstubs..."
+run "bundle binstubs webpacker --force"
+
+puts "Upgrading @rails/webpacker module..."
+run "yarn upgrade @rails/webpacker --latest"
+
+puts "Webpacker successfully installed 🎉 🍰"
+puts "Please check in any changes in binstubs, package.json or yarn.lock."

--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -2,7 +2,8 @@ INSTALLERS = {
   "Angular": :angular,
   "Elm": :elm,
   "React": :react,
-  "Vue": :vue
+  "Vue": :vue,
+  "Upgrade": :upgrade
 }.freeze
 
 namespace :webpacker do

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -6,6 +6,7 @@ tasks = {
   "webpacker:check_binstubs"          => "Verifies that bin/webpack & bin/webpack-dev-server are present",
   "webpacker:verify_install"          => "Verifies if webpacker is installed",
   "webpacker:yarn_install"            => "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn",
+  "webpacker:install:upgrade"         => "Upgrades webpacker Ruby binstubs and upgrades @rails/webpacker via Yarn.",
   "webpacker:install:react"           => "Installs and setup example React component",
   "webpacker:install:vue"             => "Installs and setup example Vue component",
   "webpacker:install:angular"         => "Installs and setup example Angular component",


### PR DESCRIPTION
After a gem bump it's not completely natural to remember to potentially bump the binstubs or yarn packages.  

This PR adds a new rake task to help with that process.

```bash
bundle exec rails webpacker:install:upgrade

# OR (on rails version < 5.0)
bundle exec rake webpacker:install:upgrade
```
